### PR TITLE
Defer IP detection to the user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,8 @@ that you want to be able to access the website without authentication
 from. It must be either a string with networks separated by comma or
 Python iterable.
 
+**Warning**: See [Getting IP Address](#getting-ip-address) below for caveats around IP address detection.
+
 ``BASIC_AUTH_REALM``
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -84,12 +86,27 @@ Example settings
 Advanced customisation
 ----------------------
 
-Getting IP
-~~~~~~~~~~
+Getting IP Address
+~~~~~~~~~~~~~~~~~~
 
-If you want to have a custom behaviour when getting IP, you can create a
-custom function that takes request as a parameter and specify path to it
-in the ``BASIC_AUTH_GET_CLIENT_IP_FUNCTION`` settings, e.g.
+By default, ``BasicAuthIPWhitelistMiddleware`` uses ``request.META["REMOTE_ADDR"]``
+as the client's IP, which corresponds to the IP address connecting to Django.
+If you have a reverse proxy (eg ``nginx`` in front), this will result in the IP address of
+``nginx``, not the client.
+
+Correctly determining the IP address can vary between deployments. Guessing incorrectly can
+result in security issues. Instead, this library requires you configure this yourselves.
+
+In most deployments, the ``X-Forwarded-For`` header can be used to correctly determine the
+client's IP. We recommend `django-xff <https://github.com/ferrix/xff>`__ to help parse this
+header correctly. Because ``django-xff`` overrides ``REMOTE_ADDR`` by default, it is natively
+supported by ``BasicAuthIPWhitelistMiddleware``.
+
+`django-ipware <https://github.com/un33k/django-ipware>`__ is another popular
+library, however may take more customization to implement.
+
+To fully customize IP address detection, you can set ``BASIC_AUTH_GET_CLIENT_IP_FUNCTION`` to
+a function which takes a request and returns a valid IP address:
 
 .. code:: python
 

--- a/baipw/middleware.py
+++ b/baipw/middleware.py
@@ -124,7 +124,10 @@ class BasicAuthIPWhitelistMiddleware:
         """
         Check if IP is on the whitelisted network.
         """
-        ip_address = ipaddress.ip_address(self._get_client_ip(request))
+        client_ip = self._get_client_ip(request)
+        if client_ip is None:
+            return False
+        ip_address = ipaddress.ip_address(client_ip)
         for network in self._get_whitelisted_networks():
             if ip_address in network:
                 return True

--- a/baipw/middleware.py
+++ b/baipw/middleware.py
@@ -6,7 +6,7 @@ from django.utils.module_loading import import_string
 
 from .exceptions import Unauthorized
 from .response import HttpUnauthorizedResponse
-from .utils import authorize, get_client_ip
+from .utils import authorize
 
 
 class BasicAuthIPWhitelistMiddleware:
@@ -61,11 +61,10 @@ class BasicAuthIPWhitelistMiddleware:
             return self.get_response_class()(request=request)
 
     def _get_client_ip(self, request):
-        function_path = getattr(settings, "BASIC_AUTH_GET_CLIENT_IP_FUNCTION", None)
-        func = get_client_ip
-        if function_path is not None:
-            func = import_string(function_path)
-        return func(request)
+        function_path = getattr(
+            settings, "BASIC_AUTH_GET_CLIENT_IP_FUNCTION", "baipw.utils.get_client_ip"
+        )
+        return import_string(function_path)(request)
 
     def _get_whitelisted_networks(self):
         networks = getattr(settings, "BASIC_AUTH_WHITELISTED_IP_NETWORKS", [])

--- a/baipw/tests/test_utils.py
+++ b/baipw/tests/test_utils.py
@@ -3,7 +3,7 @@ import base64
 from django.test import RequestFactory, TestCase
 
 from baipw.exceptions import Unauthorized
-from baipw.utils import authorize, get_client_ip
+from baipw.utils import authorize
 
 
 class TestAuthorize(TestCase):
@@ -43,39 +43,3 @@ class TestAuthorize(TestCase):
         self.assertEqual(
             str(e.exception), "Invalid format of the authorization header."
         )
-
-
-class TestGetClientIP(TestCase):
-    def setUp(self):
-        self.request = RequestFactory().get("/")
-
-    def test_get_client_ip_from_remote_addr(self):
-        self.request.META["REMOTE_ADDR"] = "192.168.0.17"
-        self.assertNotIn("HTTP_X_FORWARDED_FOR", self.request.META)
-        self.assertIn("REMOTE_ADDR", self.request.META)
-        self.assertEqual(get_client_ip(self.request), "192.168.0.17")
-
-    def test_get_client_ip_if_no_remote_addr_or_x_forwaded_for(self):
-        del self.request.META["REMOTE_ADDR"]
-        self.assertNotIn("HTTP_X_FORWARDED_FOR", self.request.META)
-        self.assertNotIn("REMOTE_ADDR", self.request.META)
-        self.assertIsNone(get_client_ip(self.request))
-
-    def test_get_client_ip_from_x_forwaded_for(self):
-        self.request.META["HTTP_X_FORWARDED_FOR"] = "72.123.123.89"
-        self.assertIn("HTTP_X_FORWARDED_FOR", self.request.META)
-        self.assertIn("REMOTE_ADDR", self.request.META)
-        self.assertEqual(get_client_ip(self.request), "72.123.123.89")
-
-    def test_get_client_ip_from_x_forwaded_for_when_multiple_values(self):
-        self.request.META["HTTP_X_FORWARDED_FOR"] = "72.123.123.89,5.123.2.45"
-        self.assertIn("HTTP_X_FORWARDED_FOR", self.request.META)
-        self.assertIn("REMOTE_ADDR", self.request.META)
-        # Should use the last IP from the list.
-        self.assertEqual(get_client_ip(self.request), "5.123.2.45")
-
-    def test_get_client_ip_prioritises_cloudflare_ip(self):
-        self.request.META["HTTP_CF_CONNECTING_IP"] = "72.123.123.90"
-        self.request.META["HTTP_X_FORWARDED_FOR"] = "110.123.123.89"
-        self.assertIn("REMOTE_ADDR", self.request.META)
-        self.assertEqual(get_client_ip(self.request), "72.123.123.90")

--- a/baipw/utils.py
+++ b/baipw/utils.py
@@ -7,26 +7,12 @@ from .exceptions import Unauthorized
 
 
 def get_client_ip(request):
-    # IP retrieved from CloudFlare
-    cf_connecting_ip = request.META.get("HTTP_CF_CONNECTING_IP")
+    """
+    Get the client's IP address
 
-    # Header usually set by proxies
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-
-    # Header set by the connecting party, usually not the actual client making
-    # the request, but a web server that the request goes through.
-    remote_addr = request.META.get("REMOTE_ADDR")
-
-    # Prioritise IPs from proxies.
-    final_ip = cf_connecting_ip or x_forwarded_for or remote_addr
-
-    # If no IP address was attached to the address, return nothing.
-    if final_ip is None:
-        return
-
-    # If there is a list of IPs provided, use the last one (should be
-    # the most recent one). This may not work on Google Cloud.
-    return final_ip.split(",")[-1].strip()
+    Note: This is the address connecting to Django, which is likely incorrect.
+    """
+    return request.META.get("REMOTE_ADDR")
 
 
 def authorize(request, configured_username, configured_password):


### PR DESCRIPTION
Fixes https://github.com/torchbox/django-basic-auth-ip-whitelist/issues/18

The correct way to do this varies so much, that it's not possible to implement 1 universal implementation