### PR TITLE
Adopt package into Torchbox

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,8 +1,0 @@
-Tomasz Knapik
-Nick Smith
-Cameron Lamb
-Todd Dembrey
-Kevin Howbrook
-Karl Hobley
-Balazs Endresz
-Thibaud Colas

--- a/LICENSE
+++ b/LICENSE
@@ -1,25 +1,27 @@
-BSD 2-Clause License
-
-Copyright (c) 2018, Tomasz Knapik
+Copyright (c) Torchbox and individual contributors.
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 django-basic-auth-ip-whitelist
 ==============================
 
-.. image:: https://github.com/tm-kn/django-basic-auth-ip-whitelist/actions/workflows/test.yml/badge.svg
+.. image:: https://github.com/torchbox/django-basic-auth-ip-whitelist/actions/workflows/test.yml/badge.svg
    :alt: GitHub actions CI status
-   :target: https://github.com/tm-kn/django-basic-auth-ip-whitelist/actions/
+   :target: https://github.com/torchbox/django-basic-auth-ip-whitelist/actions/
 .. image:: https://img.shields.io/pypi/v/django-basic-auth-ip-whitelist.svg
    :target: https://pypi.org/project/django-basic-auth-ip-whitelist/
 .. image:: https://img.shields.io/pypi/dm/django-basic-auth-ip-whitelist.svg

--- a/SECURITY.rst
+++ b/SECURITY.rst
@@ -1,8 +1,0 @@
-Security Policy
-===============
-
-Reporting a vulnerability
--------------------------
-
-Please report any security vulnerability to tomasz@knapik.net. I appreciate if you
-report this first privately before creating a public issue.

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,10 @@ version = attr: baipw.__version__
 description = Hide your Django site behind basic authentication mechanism with IP whitelisting support.
 long-description = file: README.rst
 long-description-content-type = text/x-rst
-author = Tomasz Knapik
-author_email = tomasz@knapik.net
-url = https://github.com/tm-kn/django-basic-auth-ip-whitelist
-license = BSD 2-Clause License
+author = Torchbox
+author_email = hello@torchbox.com
+url = https://github.com/torchbox/django-basic-auth-ip-whitelist
+license = BSD 3-Clause License
 classifiers =
     Development Status :: 5 - Production/Stable
     License :: OSI Approved


### PR DESCRIPTION
Fixes #21 

The most surprising change migth be the removal of the `SECURITY.rst`. Removing it forces GitHub to show the one for our organisation: https://github.com/torchbox/.github/blob/main/SECURITY.md

This also implements a small relicense from BSD-2 to BSD-3, which is more useful for an organisation.