### PR TITLE
Support multiple Authorization headers

### DIFF
--- a/baipw/tests/test_utils.py
+++ b/baipw/tests/test_utils.py
@@ -15,7 +15,7 @@ class TestAuthorize(TestCase):
             authorize(self.request, "somelogin", "somepassword")
         self.assertEqual(
             str(e.exception),
-            '"HTTP_AUTHORIZATION" is not present in the request object.',
+            "Missing Authorization header.",
         )
 
     def test_authorise_with_wrong_credentials(self):
@@ -40,6 +40,13 @@ class TestAuthorize(TestCase):
         self.request.META["HTTP_AUTHORIZATION"] = "Basic"
         with self.assertRaises(Unauthorized) as e:
             authorize(self.request, "somelogin", "wrongpassword")
-        self.assertEqual(
-            str(e.exception), "Invalid format of the authorization header."
+        self.assertEqual(str(e.exception), "Invalid Authorization header.")
+
+    def test_multiple_header_values(self):
+        credentials = base64.b64encode(
+            "somelogin:correctpassword".encode("utf-8")
+        ).decode("utf-8")
+        self.request.META["HTTP_AUTHORIZATION"] = (
+            f"Basic {credentials},Basic {credentials}"
         )
+        self.assertTrue(authorize(self.request, "somelogin", "correctpassword"))

--- a/baipw/utils.py
+++ b/baipw/utils.py
@@ -22,10 +22,10 @@ def authorize(request, configured_username, configured_password):
     """
     # Use request.META instead of request.headers to make it
     # compatible with Django versions below 2.2.
-    if "HTTP_AUTHORIZATION" not in request.META:
-        raise Unauthorized('"HTTP_AUTHORIZATION" is not present in the request object.')
+    authentication = request.META.get("HTTP_AUTHORIZATION")
 
-    authentication = request.META["HTTP_AUTHORIZATION"]
+    if authentication is None:
+        raise Unauthorized("Missing Authorization header.")
 
     disable_consumption = getattr(
         settings,
@@ -37,17 +37,19 @@ def authorize(request, configured_username, configured_password):
         # mechanisms do not try to use it.
         request.META.pop("HTTP_AUTHORIZATION")
 
-    authentication_tuple = authentication.split(" ", 1)
-    if len(authentication_tuple) != 2:
-        raise Unauthorized("Invalid format of the authorization header.")
-    auth_method = authentication_tuple[0]
-    auth = authentication_tuple[1]
-    if "basic" != auth_method.lower():
-        raise Unauthorized('"Basic" is not an authorization method.')
-    auth = base64.b64decode(auth.strip()).decode("utf-8")
-    username, password = auth.split(":", 1)
-    username_valid = constant_time_compare(username, configured_username)
-    password_valid = constant_time_compare(password, configured_password)
-    if username_valid & password_valid:
-        return True
+    for authentication in authentication.split(","):
+        authentication_tuple = authentication.split(" ", 1)
+        if len(authentication_tuple) != 2:
+            raise Unauthorized("Invalid Authorization header.")
+        auth_method = authentication_tuple[0]
+        auth = authentication_tuple[1]
+        if "basic" != auth_method.lower():
+            raise Unauthorized("Invalid Authorization header.")
+        auth = base64.b64decode(auth.strip()).decode("utf-8")
+        username, password = auth.split(":", 1)
+        username_valid = constant_time_compare(username, configured_username)
+        password_valid = constant_time_compare(password, configured_password)
+        if username_valid and password_valid:
+            return True
+
     raise Unauthorized("Basic authentication credentials are invalid.")


### PR DESCRIPTION
Fixes https://github.com/torchbox/django-basic-auth-ip-whitelist/issues/26

If any are correct, let the user in

WSGI [defines](https://stackoverflow.com/a/1801177) that when multiple headers are provided, they should be comma-separated.